### PR TITLE
Track Airtags and MFA-compliant clones using decrypted plist files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,13 @@ services:
     build: https://github.com/jannisko/findmy-traccar-bridge.git
     volumes:
       - ./:/bridge/data
+      # Optional: Mount a directory with plist files for AirTags
+      - /path/to/your/plists:/bridge/plists
     environment:
+      # Either use BRIDGE_PRIVATE_KEYS for OpenHaystack beacons
       BRIDGE_PRIVATE_KEYS: "<key1>,<key2>,..."
+      # Or use BRIDGE_PLIST_DIR for AirTags (or use both)
+      # BRIDGE_PLIST_DIR: "/bridge/plists"
       BRIDGE_TRACCAR_SERVER: "<your traccar base url>:5055"
 ```
 
@@ -87,8 +92,8 @@ docker compose exec bridge .venv/bin/findmy-traccar-bridge-init
 
 The script can be configured via the following environment variables:
 
-- `BRIDGE_PRIVATE_KEYS` - required (unless `BRIDGE_PLIST_PATHS` is set) - comma separated string of base64 encoded private keys of your beacons (e.g. can be generated via instructions from [macless-haystack](https://github.com/dchristl/macless-haystack?tab=readme-ov-file#hardware-setup))
-- `BRIDGE_PLIST_PATHS` - required (unless `BRIDGE_PRIVATE_KEYS` is set) - comma separated full paths to [decrypted plist files](https://github.com/malmeloo/FindMy.py/issues/31).
+- `BRIDGE_PRIVATE_KEYS` - required (unless `BRIDGE_PLIST_DIR` is set) - comma separated string of base64 encoded private keys of your beacons (e.g. can be generated via instructions from [macless-haystack](https://github.com/dchristl/macless-haystack?tab=readme-ov-file#hardware-setup))
+- `BRIDGE_PLIST_DIR` - required (unless `BRIDGE_PRIVATE_KEYS` is set) - directory path containing [decrypted plist files](https://github.com/malmeloo/FindMy.py/issues/31) for AirTags and MFA-compliant clones. All files with .plist extension in this directory will be loaded.
 - `BRIDGE_TRACCAR_SERVER` - required - url to your traccar server
 - `BRIDGE_ANISETTE_SERVER` - optional (default: `https://ani.sidestore.io`) - url to the anisette server used for login
 - `BRIDGE_POLL_INTERVAL` - optional (default: 3600 (60 minutes)) - time to wait between querying the apple API. Too frequent polling might get your account banned.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ of your custom tracking beacons from Apple's FindMy network.
 ## Requirements
 
 - Docker or Python 3.12
-- Some OpenHaystack beacons generating data
+- Some OpenHaystack beacons generating data, or [decrypted plist files](https://github.com/malmeloo/FindMy.py/issues/31) for real Airtags
   - e.g. an [esp32](https://github.com/dchristl/macless-haystack/blob/main/firmware/ESP32/README.md) or [NRF51](https://github.com/dchristl/macless-haystack/blob/main/firmware/nrf5x/README.md)
   - I recommend following the instructions `2. Hardware setup` from [macless-haystack](https://github.com/dchristl/macless-haystack?tab=readme-ov-file#setup). This is also where you will generate the private key for later.
 - Access to an Apple account with 2FA enabled
@@ -87,7 +87,8 @@ docker compose exec bridge .venv/bin/findmy-traccar-bridge-init
 
 The script can be configured via the following environment variables:
 
-- `BRIDGE_PRIVATE_KEYS` - required - comma separated string of base64 encoded private keys of your beacons (e.g. can be generated via instructions from [macless-haystack](https://github.com/dchristl/macless-haystack?tab=readme-ov-file#hardware-setup))
+- `BRIDGE_PRIVATE_KEYS` - required (unless `BRIDGE_PLIST_PATHS` is set) - comma separated string of base64 encoded private keys of your beacons (e.g. can be generated via instructions from [macless-haystack](https://github.com/dchristl/macless-haystack?tab=readme-ov-file#hardware-setup))
+- `BRIDGE_PLIST_PATHS` - required (unless `BRIDGE_PRIVATE_KEYS` is set) - comma separated full paths to [decrypted plist files](https://github.com/malmeloo/FindMy.py/issues/31).
 - `BRIDGE_TRACCAR_SERVER` - required - url to your traccar server
 - `BRIDGE_ANISETTE_SERVER` - optional (default: `https://ani.sidestore.io`) - url to the anisette server used for login
 - `BRIDGE_POLL_INTERVAL` - optional (default: 3600 (60 minutes)) - time to wait between querying the apple API. Too frequent polling might get your account banned.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ services:
       # Optional: Mount a directory with plist files for AirTags
       - /path/to/your/plists:/bridge/plists
     environment:
-      # Either use BRIDGE_PRIVATE_KEYS for OpenHaystack beacons
+      # For OpenHaystack beacons, specify their private keys
       BRIDGE_PRIVATE_KEYS: "<key1>,<key2>,..."
-      # Or use BRIDGE_PLIST_DIR for AirTags (or use both)
-      # BRIDGE_PLIST_DIR: "/bridge/plists"
+      # Optional: Override the default directory for plist files
+      # BRIDGE_PLIST_DIR: "/some/other/path"
       BRIDGE_TRACCAR_SERVER: "<your traccar base url>:5055"
 ```
 
@@ -48,9 +48,11 @@ services:
   ```shell
   docker build -t findmy-traccar-bridge https://github.com/jannisko/findmy-traccar-bridge.git
   docker run -d --name bridge \
-  -v ./:/data
-  -e BRIDGE_PRIVATE_KEYS="<key1>,<key2>,..."
-  -e BRIDGE_TRACCAR_URL="<your traccar base url>"
+  -v ./:/data \
+  # Optional: Mount directory with plist files for AirTags
+  -v /path/to/your/plists:/bridge/plists \
+  -e BRIDGE_PRIVATE_KEYS="<key1>,<key2>,..." \
+  -e BRIDGE_TRACCAR_URL="<your traccar base url>" \
   findmy-traccar-bridge
   ```
 </details>
@@ -59,7 +61,13 @@ services:
   <summary>as a python package</summary>
 
   ```shell
+  # Set up environment variables
   export BRIDGE_PRIVATE_KEYS="<key1>,<key2>,..." BRIDGE_TRACCAR_SERVER="<your traccar base url>"
+  # If you want to use AirTags through plist files, they'll be detected automatically in /bridge/plists
+  # Optionally you can override the plist directory:
+  # export BRIDGE_PLIST_DIR="/path/to/your/plists"
+  
+  # Run the bridge
   uvx --from=git+https://github.com/jannisko/findmy-traccar-bridge findmy-traccar-bridge
   ```
 </details>
@@ -92,8 +100,8 @@ docker compose exec bridge .venv/bin/findmy-traccar-bridge-init
 
 The script can be configured via the following environment variables:
 
-- `BRIDGE_PRIVATE_KEYS` - required (unless `BRIDGE_PLIST_DIR` is set) - comma separated string of base64 encoded private keys of your beacons (e.g. can be generated via instructions from [macless-haystack](https://github.com/dchristl/macless-haystack?tab=readme-ov-file#hardware-setup))
-- `BRIDGE_PLIST_DIR` - required (unless `BRIDGE_PRIVATE_KEYS` is set) - directory path containing [decrypted plist files](https://github.com/malmeloo/FindMy.py/issues/31) for AirTags and MFA-compliant clones. All files with .plist extension in this directory will be loaded.
+- `BRIDGE_PRIVATE_KEYS` - comma separated string of base64 encoded private keys of your OpenHaystack beacons (e.g. can be generated via instructions from [macless-haystack](https://github.com/dchristl/macless-haystack?tab=readme-ov-file#hardware-setup))
+- `BRIDGE_PLIST_DIR` - (optional) override the default directory path for [decrypted plist files](https://github.com/malmeloo/FindMy.py/issues/31). By default, the app will look for .plist files in `/bridge/plists`. Only set this if you need to use a different location.
 - `BRIDGE_TRACCAR_SERVER` - required - url to your traccar server
 - `BRIDGE_ANISETTE_SERVER` - optional (default: `https://ani.sidestore.io`) - url to the anisette server used for login
 - `BRIDGE_POLL_INTERVAL` - optional (default: 3600 (60 minutes)) - time to wait between querying the apple API. Too frequent polling might get your account banned.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ services:
     environment:
       # For OpenHaystack beacons, specify their private keys
       BRIDGE_PRIVATE_KEYS: "<key1>,<key2>,..."
-      # Optional: Override the default directory for plist files
-      # BRIDGE_PLIST_DIR: "/some/other/path"
       BRIDGE_TRACCAR_SERVER: "<your traccar base url>:5055"
       BRIDGE_ANISETTE_SERVER: "http://anisette:6969"
   anisette:

--- a/findmy_traccar_bridge/bridge.py
+++ b/findmy_traccar_bridge/bridge.py
@@ -73,15 +73,18 @@ def bridge() -> None:
     Callable via the binary `.venv/bin/findmy-traccar-bridge`
     """
 
-    private_keys = (os.environ.get("BRIDGE_PRIVATE_KEYS") or "").split(",")
-    plist_paths = (os.environ["BRIDGE_PLIST_PATHS"] or "").split(",")
+    private_keys = [k for k in (os.environ.get("BRIDGE_PRIVATE_KEYS") or "").split(",") if k]
+    plist_paths = [p for p in (os.environ.get("BRIDGE_PLIST_PATHS") or "").split(",") if p]
     if len(private_keys) + len(plist_paths) == 0:
         raise ValueError("env variable BRIDGE_PRIVATE_KEYS and/or BRIDGE_PLIST_PATHS must be set")
 
     real_airtags = []
     for plist in plist_paths:
-        with Path(plist).open("rb") as f:
-            real_airtags.append(FindMyAccessory.from_plist(f))
+        try:
+            with Path(plist).open("rb") as f:
+                real_airtags.append(FindMyAccessory.from_plist(f))
+        except Exception as e:
+            logger.error("Failed to load plist file {}: {}", plist, str(e))
 
     TRACCAR_SERVER = os.environ["BRIDGE_TRACCAR_SERVER"]
 

--- a/findmy_traccar_bridge/bridge.py
+++ b/findmy_traccar_bridge/bridge.py
@@ -105,14 +105,21 @@ def bridge() -> None:
 
     haystack_keys = [KeyPair.from_b64(key) for key in private_keys]
 
-    logger.info(
-        "Successfully parsed private keys for {} Haystack device{} and {} Airtag{}",
-        len(haystack_keys),
-        "" if len(haystack_keys) == 1 else "s",
-        len(real_airtags),
-        "" if len(real_airtags) == 1 else "s",
-
-    )
+    logger.info("Configured {} device{}:",
+                len(haystack_keys) + len(real_airtags),
+                "" if len(real_airtags) == 1 else "s")
+    for key in haystack_keys:
+        logger.info(
+            "   Haystack device\t| Private key: {}[...]\t\t|\tTraccar ID {}",
+            key.hashed_adv_key_b64[:16],
+            int.from_bytes(key.hashed_adv_key_bytes) % 1_000_000
+        )
+    for airtag in real_airtags:
+        logger.info(
+            "   FindMy device\t\t| plist identifier: {}[...]\t|\tTraccar ID {}",
+            airtag.identifier[:16],
+            int.from_bytes(airtag.identifier.encode()) % 1_000_000
+        )
 
     persistent_data: PersistentData = json.loads(persistent_data_store.read_text())
     last_traccar_push_timestamp = 0  # not super important, so not persistent


### PR DESCRIPTION
Draft PR for also tracking "real" Airtags (or MFA-certified clones) that have been added to the network via an Apple device.

This requires extracting plist files from a computer running MacOS Sonoma or Ventura, AFAIK.

I'm running this code myself right now and it is working well so far with two plist files added.

This feature should open great this project up to more people, since it removes the need to solder and re-program beacons yourself. It also reaps the privacy benefits of the rotating keys on Airtags and their MFA compliant clones.

Let me know what you think!
